### PR TITLE
Version 2.0.0.2311

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     strategy:
       matrix:
-        dotnet: ['5.0.x', '6.0.x', '7.0.x']
+        dotnet: ['8.0.x']
         os: ['ubuntu-latest', 'windows-latest']
     runs-on: ${{ matrix.os }}
     name: .NET ${{ matrix.dotnet }} on ${{ matrix.os }} sample

--- a/NUGET_README.md
+++ b/NUGET_README.md
@@ -37,6 +37,7 @@ PeyrSharp is divided in multiple packages:
 - Crypt
 - XmlHelper
 - JsonHelper
+- StatusInfo
 
 **PeyrSharp.Env**, methods related to the file system and to the current execution environment.
 
@@ -74,6 +75,8 @@ PeyrSharp is divided in multiple packages:
 
 - WinForms
 - Screen
+- WindowHelpers
+- WindowInfo
 - WPF
 
 ## Compatibility
@@ -101,11 +104,11 @@ Caption:
 
 PeyrSharp is available in the following frameworks
 
-- .NET 5
 - .NET 6
 - .NET 7
+- .NET 8
 
-> Note: .NET Framework and .NET Core are not targeted by PeyrSharp, since they are no longer supported.
+> Note: .NET Framework, .NET Core and .NET 5 are not targeted by PeyrSharp, since they are no longer supported.
 
 ## Documentation
 
@@ -128,9 +131,9 @@ Here's what you'll need to contribute to this project:
   - .NET Desktop Development
   - Git
 - .NET
-  - .NET 5 (SDK + runtime)
   - .NET 6 (SDK + runtime)
   - .NET 7 (SDK + runtime)
+  - .NET 8 (SDK + runtime)
 - (_optional_) NuGet
 
 ## Badge

--- a/PeyrSharp.Core/PeyrSharp.Core.csproj
+++ b/PeyrSharp.Core/PeyrSharp.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <Title>PeyrSharp.Core</Title>
     <Version>1.10.0.2310</Version>

--- a/PeyrSharp.Core/PeyrSharp.Core.csproj
+++ b/PeyrSharp.Core/PeyrSharp.Core.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <Title>PeyrSharp.Core</Title>
-    <Version>1.10.0.2310</Version>
+    <Version>2.0.0.2311</Version>
     <Authors>Devyus</Authors>
     <Description>Core methods and features of PeyrSharp.</Description>
     <Copyright>© 2023</Copyright>
@@ -16,7 +16,8 @@
     <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <PackageReleaseNotes></PackageReleaseNotes>
+    <PackageReleaseNotes>- Added .NET 8 Support
+- Removed .NET 5 Support</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>
@@ -31,8 +32,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="PeyrSharp.Enums" Version="1.10.0.2310" />
-    <PackageReference Include="PeyrSharp.Exceptions" Version="1.10.0.2310" />
+    <PackageReference Include="PeyrSharp.Enums" Version="2.0.0.2311" />
+    <PackageReference Include="PeyrSharp.Exceptions" Version="2.0.0.2311" />
   </ItemGroup>
 
 </Project>

--- a/PeyrSharp.Enums/PeyrSharp.Enums.csproj
+++ b/PeyrSharp.Enums/PeyrSharp.Enums.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net5.0;net6.0;net7.0</TargetFrameworks>
+		<TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
 		<ImplicitUsings>disable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<Title>PeyrSharp.Enums</Title>

--- a/PeyrSharp.Enums/PeyrSharp.Enums.csproj
+++ b/PeyrSharp.Enums/PeyrSharp.Enums.csproj
@@ -11,14 +11,15 @@
 		<PackageProjectUrl>https://peyrsharp.leocorporation.dev/</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/DevyusCode/PeyrSharp</RepositoryUrl>
 		<PackageTags>enums;c-sharp;dotnet;vb;peyrsharp;leo corp</PackageTags>
-		<Version>1.10.0.2310</Version>
+		<Version>2.0.0.2311</Version>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<PackageIcon>logo.png</PackageIcon>
 		<PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<RepositoryType>git</RepositoryType>
-		<PackageReleaseNotes></PackageReleaseNotes>
+		<PackageReleaseNotes>- Added .NET 8 Support
+- Removed .NET 5 Support</PackageReleaseNotes>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/PeyrSharp.Env/PeyrSharp.Env.csproj
+++ b/PeyrSharp.Env/PeyrSharp.Env.csproj
@@ -4,7 +4,7 @@
 		<TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
 		<Title>PeyrSharp.Env</Title>
-		<Version>1.10.0.2310</Version>
+		<Version>2.0.0.2311</Version>
 		<Authors>Devyus</Authors>
 		<Description>Environment-related methods of PeyrSharp.</Description>
 		<Copyright>© 2023</Copyright>
@@ -16,7 +16,8 @@
 		<PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-		<PackageReleaseNotes></PackageReleaseNotes>
+		<PackageReleaseNotes>- Added .NET 8 Support
+- Removed .NET 5 Support</PackageReleaseNotes>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -32,6 +33,6 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
-		<PackageReference Include="PeyrSharp.Enums" Version="1.10.0.2310" />
+		<PackageReference Include="PeyrSharp.Enums" Version="2.0.0.2311" />
 	</ItemGroup>
 </Project>

--- a/PeyrSharp.Env/PeyrSharp.Env.csproj
+++ b/PeyrSharp.Env/PeyrSharp.Env.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net5.0;net6.0;net7.0</TargetFrameworks>
+		<TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
 		<Title>PeyrSharp.Env</Title>
 		<Version>1.10.0.2310</Version>

--- a/PeyrSharp.Exceptions/PeyrSharp.Exceptions.csproj
+++ b/PeyrSharp.Exceptions/PeyrSharp.Exceptions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>

--- a/PeyrSharp.Exceptions/PeyrSharp.Exceptions.csproj
+++ b/PeyrSharp.Exceptions/PeyrSharp.Exceptions.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Title>PeyrSharp.Exceptions</Title>
-    <Version>1.10.0.2310</Version>
+    <Version>2.0.0.2311</Version>
     <Company>Devyus</Company>
     <Description>Exceptions of PeyrSharp.</Description>
     <Copyright>© 2023</Copyright>
@@ -18,6 +18,8 @@
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryType>git</RepositoryType>
+    <PackageReleaseNotes>- Added .NET 8 Support
+- Removed .NET 5 Support</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>

--- a/PeyrSharp.Extensions/PeyrSharp.Extensions.csproj
+++ b/PeyrSharp.Extensions/PeyrSharp.Extensions.csproj
@@ -4,7 +4,7 @@
 		<TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
 		<Title>PeyrSharp.Extensions</Title>
-		<Version>1.10.0.2310</Version>
+		<Version>2.0.0.2311</Version>
 		<Authors>Devyus</Authors>
 		<Description>Extensions methods of PeyrSharp.</Description>
 		<Copyright>© 2023</Copyright>
@@ -16,7 +16,8 @@
 		<PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-		<PackageReleaseNotes></PackageReleaseNotes>
+		<PackageReleaseNotes>- Added .NET 8 Support
+- Removed .NET 5 Support</PackageReleaseNotes>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -31,7 +32,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="PeyrSharp.Enums" Version="1.10.0.2310" />
+		<PackageReference Include="PeyrSharp.Enums" Version="2.0.0.2311" />
 	</ItemGroup>
 
 </Project>

--- a/PeyrSharp.Extensions/PeyrSharp.Extensions.csproj
+++ b/PeyrSharp.Extensions/PeyrSharp.Extensions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net5.0;net6.0;net7.0</TargetFrameworks>
+		<TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
 		<Title>PeyrSharp.Extensions</Title>
 		<Version>1.10.0.2310</Version>

--- a/PeyrSharp.UiHelpers/PeyrSharp.UiHelpers.csproj
+++ b/PeyrSharp.UiHelpers/PeyrSharp.UiHelpers.csproj
@@ -8,7 +8,7 @@
 		<UseWPF>true</UseWPF>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
 		<Title>PeyrSharp.UiHelpers</Title>
-		<Version>1.10.0.2310</Version>
+		<Version>2.0.0.2311</Version>
 		<Authors>Devyus</Authors>
 		<Description>Useful helpers for Windows Forms and Windows Presentation Framework.</Description>
 		<Copyright>© 2023</Copyright>
@@ -20,14 +20,8 @@
 		<PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-		<PackageReleaseNotes>- Added the possibility to close windows (#143)
-- Added the possibility to maximize windows (#143)
-- Added the possibility to restore windows (#143)
-- Added the possibility to minimize windows (#143)
-- Added XML documentation (#143)
-- Added the possibility to set the position of any window (#144)
-- Added SetTopMost() method (#145)
-- Added GetWindowSize() method (#146)</PackageReleaseNotes>
+		<PackageReleaseNotes>- Added .NET 8 Support
+- Removed .NET 5 Support</PackageReleaseNotes>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -42,7 +36,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="PeyrSharp.Enums" Version="1.10.0.2310" />
+		<PackageReference Include="PeyrSharp.Enums" Version="2.0.0.2311" />
 	</ItemGroup>
 
 </Project>

--- a/PeyrSharp.UiHelpers/PeyrSharp.UiHelpers.csproj
+++ b/PeyrSharp.UiHelpers/PeyrSharp.UiHelpers.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net5.0-windows;net6.0-windows;net7.0-windows</TargetFrameworks>
+		<TargetFrameworks>net6.0-windows;net7.0-windows;net8.0-windows</TargetFrameworks>
 		<ImplicitUsings>disable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<UseWindowsForms>true</UseWindowsForms>

--- a/PeyrSharp/PeyrSharp.cs
+++ b/PeyrSharp/PeyrSharp.cs
@@ -32,6 +32,6 @@ namespace PeyrSharp
 		/// <summary>
 		/// The current version of PeyrSharp.
 		/// </summary>
-		public static string Version => "1.10.0.2310";
+		public static string Version => "2.0.0.2311";
 	}
 }

--- a/PeyrSharp/PeyrSharp.csproj
+++ b/PeyrSharp/PeyrSharp.csproj
@@ -4,7 +4,7 @@
 		<TargetFrameworks>net6.0;net6.0-windows;net7.0;net7.0-windows;net8.0;net8.0-windows</TargetFrameworks>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
 		<Title>PeyrSharp</Title>
-		<Version>1.10.0.2310</Version>
+		<Version>2.0.0.2311</Version>
 		<Authors>Devyus</Authors>
 		<Copyright>© 2023</Copyright>
 		<Description>A C# library designed to make developers' job easier.</Description>
@@ -17,15 +17,9 @@
 		<PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-		<PackageReleaseNotes>(for Windows only)
-- Added the possibility to close windows (#143)
-- Added the possibility to maximize windows (#143)
-- Added the possibility to restore windows (#143)
-- Added the possibility to minimize windows (#143)
-- Added XML documentation (#143)
-- Added the possibility to set the position of any window (#144)
-- Added SetTopMost() method (#145)
-- Added GetWindowSize() method (#146)</PackageReleaseNotes>
+		<PackageReleaseNotes>- Added .NET 8 Support
+- Removed .NET 5 Support
+		</PackageReleaseNotes>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -40,12 +34,12 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="PeyrSharp.Core" Version="1.10.0.2310" />
-		<PackageReference Include="PeyrSharp.Enums" Version="1.10.0.2310" />
-		<PackageReference Include="PeyrSharp.Env" Version="1.10.0.2310" />
-		<PackageReference Include="PeyrSharp.Exceptions" Version="1.10.0.2310" />
-		<PackageReference Include="PeyrSharp.Extensions" Version="1.10.0.2310" />
-		<PackageReference Condition="'$(TargetPlatformIdentifier)' == 'Windows'" Include="PeyrSharp.UiHelpers" Version="1.10.0.2310" />
+		<PackageReference Include="PeyrSharp.Core" Version="2.0.0.2311" />
+		<PackageReference Include="PeyrSharp.Enums" Version="2.0.0.2311" />
+		<PackageReference Include="PeyrSharp.Env" Version="2.0.0.2311" />
+		<PackageReference Include="PeyrSharp.Exceptions" Version="2.0.0.2311" />
+		<PackageReference Include="PeyrSharp.Extensions" Version="2.0.0.2311" />
+		<PackageReference Condition="'$(TargetPlatformIdentifier)' == 'Windows'" Include="PeyrSharp.UiHelpers" Version="2.0.0.2311" />
 	</ItemGroup>
 
 </Project>

--- a/PeyrSharp/PeyrSharp.csproj
+++ b/PeyrSharp/PeyrSharp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net5.0;net6.0;net5.0-windows;net6.0-windows;net7.0;net7.0-windows</TargetFrameworks>
+		<TargetFrameworks>net6.0;net6.0-windows;net7.0;net7.0-windows;net8.0;net8.0-windows</TargetFrameworks>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
 		<Title>PeyrSharp</Title>
 		<Version>1.10.0.2310</Version>

--- a/README.md
+++ b/README.md
@@ -29,12 +29,6 @@
 
 ## Introduction
 
-### The roots
-
-In March 2020, we published LeoCorpLibrary, which was also a C# library that contains useful methods. When we started the development of it, we didn't know where the project will go yet. Over the releases, we've added more and more methods and new features. However, the meaning and the purpose of LeoCorpLibrary was becoming less clear for everyone; it was becoming a mess. This is why we decided to rather not release v5, but instead, we decided to make a brand new .NET Library, PeyrSharp.
-
-### Our next product
-
 PeyrSharp is a C# written library designed to make developers' life easier. We've all written code that we wish we hadn't. PeyrSharp is here to respond to this need; by implementing useful methods in various domains: Mathematics, Web/HTTP requests, unit converters, extensions, environment-related operations, and more!
 
 ## Modules
@@ -56,6 +50,7 @@ PeyrSharp is divided in multiple packages:
 - Crypt
 - XmlHelper
 - JsonHelper
+- StatusInfo
 
 </details>
 
@@ -118,6 +113,8 @@ PeyrSharp is divided in multiple packages:
 
 - WinForms
 - Screen
+- WindowHelpers
+- WindowInfo
 - WPF
 
 </details>
@@ -147,11 +144,11 @@ Caption:
 
 PeyrSharp is available in the following frameworks
 
-- .NET 5
 - .NET 6
 - .NET 7
+- .NET 8
 
-> Note: .NET Framework and .NET Core are not targeted by PeyrSharp, since they are no longer supported.
+> Note: .NET Framework, .NET Core and .NET 5 are not targeted by PeyrSharp, since they are no longer supported.
 
 ## Documentation
 
@@ -179,9 +176,9 @@ Here's what you'll need to contribute to this project:
   - .NET Desktop Development
   - Git
 - .NET
-  - .NET 5 (SDK + runtime)
   - .NET 6 (SDK + runtime)
   - .NET 7 (SDK + runtime)
+  - .NET 8 (SDK + runtime)
 - (_optional_) NuGet
 
 ## Badge


### PR DESCRIPTION
- Added .NET 8 Support - closes #151 
- Removed .NET 5 Support - closes #152 

> Note: .NET Framework, .NET Core and .NET 5 are not targeted by PeyrSharp, since they are no longer supported.